### PR TITLE
Add additional env vars to pass into container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
       - ren-data:/data
     environment:
       - TOKEN=${TOKEN}
-      - PREFIX=${PREFIX:-.}
+      - PREFIX=${PREFIX}
       - TZ=${TIMEZONE:-America/Vancouver}
       - PUID=1000
+      - CUSTOM_REDBOT_PACKAGE=git+https://github.com/SFUAnime/Ren.git@V3/testing
+      - EXTRA_ARGS=${EXTRA_ARGS}

--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,11 @@ We need to do this because our application needs a token to connect to Discord A
 First we need to update the compose file with our token before running the script
 
 - Create a `.env` file with the following environment variables:
-    - `TOKEN`: The bot's token from the Discord Developer Portal.
-    - `PREFIX`: The bot's prefix. Defaults to `.`
+    - `TOKEN`: The bot's token from the Discord Developer Portal. Set this only if you're setting
+      it up for the first time.
+    - `PREFIX`: The bot's prefix. Set this only if you're setting it up for the first time.
     - `TIMEZONE`: The container's timezone. Defaults to `America/Vancouver`.
+    - `EXTRA_ARGS`: Extra arguments to pass into the invocation of `redbot`.
 - Run `docker compose up -d`.
 
 This will create the docker container, network, and volumes to save persistent data


### PR DESCRIPTION
We have made some changes into Red-DiscordBot, namely the Alias cog. As such, we'll need to use our version of it (Ren).

In addition, the `TOKEN` and `PREFIX` environment variables are only needed for the first time. Subsequent run

To address the above, this PR will:
- Remove the `TOKEN`
- Add the `CUSTOM_REDBOT_PACKAGE` envvar to point to our fork.
- Add the `EXTRA_ARGS` envvar, which we use to pass additional flags for debug info.