### PR TITLE
compose: Re-add docker volumes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,3 +22,7 @@ services:
       - PUID=1000
       - CUSTOM_REDBOT_PACKAGE=git+https://github.com/SFUAnime/Ren.git@V3/testing
       - EXTRA_ARGS=${EXTRA_ARGS}
+
+volumes:
+  ren-data:
+    name: ren-data


### PR DESCRIPTION
# Description of changes
This PR reverts a change made in #1 that accidentally removed the named volumes.

# Testing
- Ran `docker compose up -d` on a fresh machine, starts without errors wrt non-existent volumes.